### PR TITLE
Add package json and support for commonjs exports

### DIFF
--- a/js/item.js
+++ b/js/item.js
@@ -153,6 +153,12 @@ if ( typeof define === 'function' && define.amd ) {
       './rect'
     ],
     itemDefinition );
+} else if ( typeof exports === 'object' ) {
+  module.exports = itemDefinition(
+    require('get-style-property'),
+    require('outlayer'),
+    require('./rect')
+  );
 } else {
   // browser global
   window.Packery.Item = itemDefinition(

--- a/js/packer.js
+++ b/js/packer.js
@@ -147,6 +147,10 @@ return Packer;
 if ( typeof define === 'function' && define.amd ) {
   // AMD
   define( [ './rect' ], packerDefinition );
+} else if ( typeof exports === 'object' ) {
+  module.exports = packerDefinition(
+    require('./rect')
+  );
 } else {
   // browser global
   var Packery = window.Packery = window.Packery || {};

--- a/js/packery.js
+++ b/js/packery.js
@@ -454,6 +454,15 @@ if ( typeof define === 'function' && define.amd ) {
       './item'
     ],
     packeryDefinition );
+} else if ( typeof exports === 'object' ) {
+  module.exports = packeryDefinition(
+    require('classie'),
+    require('get-size'),
+    require('outlayer'),
+    require('./rect'),
+    require('./packer'),
+    require('./item')
+  );
 } else {
   // browser global
   window.Packery = packeryDefinition(

--- a/js/rect.js
+++ b/js/rect.js
@@ -150,6 +150,8 @@ return Rect;
 if ( typeof define === 'function' && define.amd ) {
   // AMD
   define( rectDefinition );
+} else if ( typeof exports === 'object' ) {
+  module.exports = rectDefinition();
 } else {
   // browser global
   window.Packery = window.Packery || {};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "packery",
+  "version": "1.2.2",
+  "description": "bin-packing layout library",
+  "main": "js/packery.js",
+  "directories": {
+    "example": "examples",
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/metafizzy/packery.git"
+  },
+  "author": "David DeSandro / Metafizzy",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/metafizzy/packery/issues"
+  },
+  "homepage": "https://github.com/metafizzy/packery",
+  "dependencies": {
+    "classie": "https://github.com/wbinnssmith/classie/archive/commonjs.tar.gz",
+    "get-size": "https://github.com/wbinnssmith/get-size/archive/packagejson.tar.gz",
+    "get-style-property": "https://github.com/wbinnssmith/get-style-property/archive/packagejson.tar.gz",
+    "outlayer": "https://github.com/wbinnssmith/outlayer/archive/commonjs-browserify.tar.gz"
+  }
+}


### PR DESCRIPTION
Though this currently has dependencies pointing to my forks, I can change the dependencies to match the originals if other PRs with package jsons are merged.
