### PR TITLE
Added methods to unbind draggabilly events

### DIFF
--- a/js/packery.js
+++ b/js/packery.js
@@ -451,6 +451,16 @@ Packery.prototype.bindDraggabillyEvents = function( draggie ) {
 };
 
 /**
+ * unbind draggabilly events 
+ * @param {Draggabilly} draggie
+ */
+Packery.prototype.unbindDraggabillyEvents = function( draggie ) {
+  draggie.off( 'dragStart', this.handleDraggabilly.dragStart );
+  draggie.off( 'dragMove', this.handleDraggabilly.dragMove );
+  draggie.off( 'dragEnd', this.handleDraggabilly.dragEnd );
+};
+
+/**
  * binds jQuery UI Draggable events
  * @param {jQuery} $elems
  */
@@ -459,6 +469,17 @@ Packery.prototype.bindUIDraggableEvents = function( $elems ) {
     .on( 'dragstart', this.handleUIDraggable.start )
     .on( 'drag', this.handleUIDraggable.drag )
     .on( 'dragstop', this.handleUIDraggable.stop );
+};
+
+/**
+ * unbinds jQuery UI Draggable events
+ * @param {jQuery} $elems
+ */
+Packery.prototype.unbindUIDraggableEvents = function( $elems ) {
+  $elems
+    .off( 'dragstart', this.handleUIDraggable.start )
+    .off( 'drag', this.handleUIDraggable.drag )
+    .off( 'dragstop', this.handleUIDraggable.stop );
 };
 
 Packery.Rect = Rect;


### PR DESCRIPTION
Fixes #72 `.destroy() does not unbind draggable events`