### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Bower: `bower install packery --save`
 
 ## License
 
-### Commerical license
+### Commercial license
 
-If you want to use Packery to develop commercial sites, themes, projects, and applications, the Commercial license is the appropriate license. With this option, your source code is kept proprietary. Purchase a Packery Commercial License at [packery.metafizzy.co](http://packery.metafizzy.co/#commerical-license)
+If you want to use Packery to develop commercial sites, themes, projects, and applications, the Commercial license is the appropriate license. With this option, your source code is kept proprietary. Purchase a Packery Commercial License at [packery.metafizzy.co](http://packery.metafizzy.co/#commercial-license)
 
 ### Open source license
 


### PR DESCRIPTION
@metafizzy, I've corrected a typographical error in the documentation of the [packery](https://github.com/metafizzy/packery) project. Specifically, I've changed commerical to commercial. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.