### PR TITLE
Allows setting additional class on dropPlaceholder

### DIFF
--- a/js/item.js
+++ b/js/item.js
@@ -95,15 +95,18 @@ proto.removeElem = function() {
 
 // ----- dropPlaceholder ----- //
 
-proto.showDropPlaceholder = function() {
+proto.showDropPlaceholder = function(additionalClass) {
   var dropPlaceholder = this.dropPlaceholder;
+  var className = 'packery-drop-placeholder';
   if ( !dropPlaceholder ) {
     // create dropPlaceholder
     dropPlaceholder = this.dropPlaceholder = document.createElement('div');
-    dropPlaceholder.className = 'packery-drop-placeholder';
+    dropPlaceholder.className = className;
     dropPlaceholder.style.position = 'absolute';
   }
-
+  if ( additionalClass !== undefined ) {
+    dropPlaceholder.className = className + ' ' + additionalClass;
+  }
   dropPlaceholder.style.width = this.size.width + 'px';
   dropPlaceholder.style.height = this.size.height + 'px';
   this.positionDropPlaceholder();

--- a/js/packery.js
+++ b/js/packery.js
@@ -414,7 +414,15 @@ proto.itemDragStart = function( elem ) {
   }
 
   item.enablePlacing();
-  item.showDropPlaceholder();
+  // get additional class from elem
+  var srcSelector = this._getOption('dropPlaceholderClassSource');
+  var srcAttr = this._getOption('dropPlaceholderSourceAttribute');
+  var additionalClass = null;
+  if ( srcSelector !== undefined && srcAttr !== undefined ) {
+    var srcElem = elem.querySelector( srcSelector );
+    var additionalClass = srcElem.getAttribute( srcAttr );
+  }
+  item.showDropPlaceholder(additionalClass);
   this.dragItemCount++;
   this.updateShiftTargets( item );
 };


### PR DESCRIPTION
I want to have the dropPlaceholder styled in a particular way by adding a specific class to the dropPlaceholder. This PR adds two additional settings:
- dropPlaceholderClassSource: selector to source element that contains attribute with hte value that you want to set on dropPlaceholder
- dropPlaceholderSourceAttribute: attribute name

I saw that options are handled in Outlayer but was not sure if these 'new' settings belong there.

Comments welcome!
