### PR TITLE
Round value to fix zoom error in chrome/safari.

### DIFF
--- a/dist/packery.pkgd.js
+++ b/dist/packery.pkgd.js
@@ -285,7 +285,7 @@ function setup() {
   body.appendChild( div );
   var style = getStyle( div );
 
-  getSize.isBoxSizeOuter = isBoxSizeOuter = getStyleSize( style.width ) == 200;
+  getSize.isBoxSizeOuter = isBoxSizeOuter = Math.round( getStyleSize( style.width ) ) == 200;
   body.removeChild( div );
 
 }


### PR DESCRIPTION
This problem happens in Chrome and Safari. Both use webkit has problem with CSS-percentage
https://www.quora.com/Are-there-workarounds-for-Webkit-CSS-percentage-rounding-issues

This code fix this issue: https://github.com/metafizzy/packery/issues/378
