### PR TITLE
Add error checking on parentNode

### DIFF
--- a/js/item.js
+++ b/js/item.js
@@ -87,7 +87,10 @@ proto.disablePlacing = function() {
 
 // remove element from DOM
 proto.removeElem = function() {
-  this.element.parentNode.removeChild( this.element );
+  var parent = this.element.parentNode;
+  if ( parent ) {
+    parent.removeChild( this.element );
+  }
   // add space back to packer
   this.layout.packer.addSpace( this.rect );
   this.emitEvent( 'remove', [ this ] );


### PR DESCRIPTION
Added error checking to block removing from parentNode if element was already removed

I was hitting errors where another library had already removed the element from parentNode.

Associated fix in https://github.com/metafizzy/outlayer/pull/52